### PR TITLE
Require Node < 25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18 <25"
       }
     },
     "node_modules/@confluentinc/kafka-javascript": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "CC0-1.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=18 <25"
   },
   "dependencies": {
     "@confluentinc/kafka-javascript": "^1.9.1"


### PR DESCRIPTION
@confluentinc/kafka-javascript only has prebuild binaries for Node 18-24.